### PR TITLE
Fix messages being dropped when parsing a stream

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -749,14 +749,9 @@ mod wpt {
 
     #[test]
     fn decode_stream_when_fed_by_line() {
-        use futures::stream::{self, TryStreamExt, StreamExt};
+        use futures::stream::{self, StreamExt, TryStreamExt};
 
-        let input: Vec<&str> = vec![":ok",
-                                    "",
-                                    "event:message",
-                                    "id:id1",
-                                    "data:data1",
-                                    ""];
+        let input: Vec<&str> = vec![":ok", "", "event:message", "id:id1", "data:data1", ""];
 
         let body_stream = stream::iter(input).map(|i| Ok(i.to_owned() + "\n"));
 
@@ -768,17 +763,8 @@ mod wpt {
         });
 
         let results = result.unwrap();
-        assert_eq!(
-            results.len(),
-            2
-        );
-        assert_eq!(
-            results.get(0).unwrap(),
-            &Event::id("id1")
-        );
-        assert_eq!(
-            results.get(1).unwrap(),
-            &Event::message("message", "data1")
-        );
+        assert_eq!(results.len(), 2);
+        assert_eq!(results.get(0).unwrap(), &Event::id("id1"));
+        assert_eq!(results.get(1).unwrap(), &Event::message("message", "data1"));
     }
 }


### PR DESCRIPTION
Before the fix all the messages that were processed were `Event::id` and the real messages were dropped/skipped.

