### PR TITLE
upgrade futures_codec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/goto-bus-stop/sse-codec"
 readme = "README.md"
 
 [dependencies]
-futures_codec = "= 0.4.1"
+futures_codec = "= 0.5.0"
 futures-io = "0.3"
 memchr = "2.2"
 arbitrary = { version = "1.0.0", features = ["derive"], optional = true }


### PR DESCRIPTION
Resolves #15 

Side-note: I'm not sure why `Cargo.lock` isn't checked in, since that shouldn't impact downstream repos.